### PR TITLE
feat: get AppDirectory from react-router/dev

### DIFF
--- a/src/next-routes.test.ts
+++ b/src/next-routes.test.ts
@@ -15,6 +15,15 @@ vi.mock('node:fs/promises', async () => {
     return memfs.fs.promises
 })
 
+vi.mock(import('@react-router/dev/routes'), async (importOriginal) => {
+    const mod = await importOriginal() // type is inferred
+    return {
+        ...mod,
+        getAppDirectory: vi.fn(() => './app'),
+        total: vi.fn(),
+    }
+})
+
 describe('direct route transform tests', () => {
     test("catchall", () => {
         const parsed = parseParameter("[...all]")

--- a/src/next-routes.test.ts
+++ b/src/next-routes.test.ts
@@ -19,8 +19,7 @@ vi.mock(import('@react-router/dev/routes'), async (importOriginal) => {
     const mod = await importOriginal() // type is inferred
     return {
         ...mod,
-        getAppDirectory: vi.fn(() => './app'),
-        total: vi.fn(),
+        getAppDirectory: vi.fn(() => './app')
     }
 })
 

--- a/src/next-routes.ts
+++ b/src/next-routes.ts
@@ -1,6 +1,6 @@
-import { readdirSync, statSync } from 'fs';
-import { join, parse, relative } from 'path';
-import { type RouteConfigEntry, route, layout } from "@react-router/dev/routes";
+import { readdirSync, statSync } from 'node:fs';
+import { join, parse, relative, resolve } from 'node:path';
+import { type RouteConfigEntry, getAppDirectory, route, layout } from "@react-router/dev/routes";
 import { deepSortByPath, parseParameter, printRoutesAsTable, printRoutesAsTree, transformRoutePath } from "./utils";
 
 type PrintOption = "no" | "info" | "table" | "tree";
@@ -56,7 +56,13 @@ function createRouteConfig(
 export function generateRouteConfig(options: Options = defaultOptions): RouteConfigEntry[] {
     const baseFolder = options.folderName || defaultOptions.folderName!;
     const printOption = options.print || defaultOptions.print!;
-    const pagesDir = "./app/" + baseFolder;
+    
+    let appDirectory = "./app"
+    try {
+        appDirectory = getAppDirectory();
+    } catch {}
+    
+    const pagesDir = resolve(appDirectory, baseFolder);
 
     /**
      * Scans a directory and returns its contents

--- a/src/next-routes.ts
+++ b/src/next-routes.ts
@@ -1,7 +1,7 @@
-import { readdirSync, statSync } from 'node:fs';
-import { join, parse, relative, resolve } from 'node:path';
-import { type RouteConfigEntry, getAppDirectory, route, layout } from "@react-router/dev/routes";
-import { deepSortByPath, parseParameter, printRoutesAsTable, printRoutesAsTree, transformRoutePath } from "./utils";
+import {readdirSync, statSync} from 'node:fs';
+import {join, parse, relative, resolve} from 'node:path';
+import {type RouteConfigEntry, getAppDirectory, route, layout} from "@react-router/dev/routes";
+import {deepSortByPath, parseParameter, printRoutesAsTable, printRoutesAsTree, transformRoutePath} from "./utils";
 
 type PrintOption = "no" | "info" | "table" | "tree";
 
@@ -31,7 +31,7 @@ function createRouteConfig(
 ): RouteConfigEntry {
     // Handle index routes in dynamic folders
     if (name === 'index' && folderName.startsWith('[') && folderName.endsWith(']')) {
-        const { routeName } = parseParameter(folderName);
+        const {routeName} = parseParameter(folderName);
         const routePath = parentPath === '' ? routeName : `${parentPath.replace(folderName, '')}${routeName}`;
         return route(transformRoutePath(routePath), relativePath);
     }
@@ -43,7 +43,7 @@ function createRouteConfig(
     }
 
     // Handle dynamic and regular routes
-    const { routeName } = parseParameter(name);
+    const {routeName} = parseParameter(name);
     const routePath = parentPath === '' ? `/${routeName}` : `${parentPath}/${routeName}`;
     return route(transformRoutePath(routePath), relativePath);
 }
@@ -56,12 +56,9 @@ function createRouteConfig(
 export function generateRouteConfig(options: Options = defaultOptions): RouteConfigEntry[] {
     const baseFolder = options.folderName || defaultOptions.folderName!;
     const printOption = options.print || defaultOptions.print!;
-    
-    let appDirectory = "./app"
-    try {
-        appDirectory = getAppDirectory();
-    } catch {}
-    
+
+    let appDirectory = getAppDirectory();
+
     const pagesDir = resolve(appDirectory, baseFolder);
 
     /**
@@ -82,7 +79,7 @@ export function generateRouteConfig(options: Options = defaultOptions): RouteCon
      */
     function scanDirectory(dir: string, parentPath: string = ''): RouteConfigEntry[] {
         const routes: RouteConfigEntry[] = [];
-        const { files, folderName } = scanDir(dir);
+        const {files, folderName} = scanDir(dir);
         const layoutFile = files.find(item => item === '_layout.tsx');
         const currentLevelRoutes: RouteConfigEntry[] = [];
 
@@ -92,7 +89,7 @@ export function generateRouteConfig(options: Options = defaultOptions): RouteCon
 
             const fullPath = join(dir, item);
             const stats = statSync(fullPath);
-            const { name, ext } = parse(item);
+            const {name, ext} = parse(item);
             const relativePath = `${baseFolder}/${relative(pagesDir, fullPath)}`;
 
             if (stats.isDirectory()) {


### PR DESCRIPTION
Currently the `rr-next-routes` assume that the react-router files are kept in "app" directory. But RR allows to change app-directory from the config, so the package should consider making routes path dynamic.