### PR TITLE
Update index routes handling and route configuration method

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "generate nextjs-style routes in your react-router-v7 application",
   "scripts": {
     "dev": "vitest watch",

--- a/src/next-routes.ts
+++ b/src/next-routes.ts
@@ -70,11 +70,21 @@ function createRouteConfig(
 }
 
 /**
+ * Generates route configuration from a Next.js-style pages directory for Remix/**
+ * @deprecated The method should not be used anymore. please use {@link nextRoutes} instead.
+ * @param options - Configuration options for route generation
+ * @returns Array of route configurations
+ */
+export function generateRouteConfig(options: Options = defaultOptions) {
+    return nextRoutes(options);
+}
+
+/**
  * Generates route configuration from a Next.js-style pages directory for Remix
  * @param options - Configuration options for route generation
  * @returns Array of route configurations
  */
-export function generateRouteConfig(options: Options = defaultOptions): RouteConfigEntry[] {
+export function nextRoutes(options: Options = defaultOptions): RouteConfigEntry[] {
     const {
         folderName: baseFolder = defaultOptions.folderName!,
         print: printOption = defaultOptions.print!,
@@ -115,7 +125,7 @@ export function generateRouteConfig(options: Options = defaultOptions): RouteCon
             return (name === layoutFileName && extensions.includes(ext));
         });
         const currentLevelRoutes: RouteConfigEntry[] = [];
-
+        
         // Process each file in the directory
         files.forEach(item => {
             if (item.startsWith('_')) return;
@@ -130,6 +140,7 @@ export function generateRouteConfig(options: Options = defaultOptions): RouteCon
                 const nestedRoutes = scanDirectory(fullPath, `${parentPath}/${name}`);
                 (layoutFile ? currentLevelRoutes : routes).push(...nestedRoutes);
             } else if (extensions.includes(ext)) {
+                // Early return if strict file names are enabled and the current item is not in the list.
                 if (routeFileNameOnly && !routeFileNames.includes(name)) return;
                 const routeConfig = createRouteConfig(name, parentPath, relativePath, folderName, routeFileNames);
                 (layoutFile ? currentLevelRoutes : routes).push(routeConfig);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,18 @@
 import type {RouteConfigEntry} from "@react-router/dev/routes";
 
 export function transformRoutePath(path: string): string {
-    return path
+    let transformedPath = path
         .replace(/\[\[\s*([^\]]+)\s*]]/g, ':$1?') // Handle optional parameters [[param]]
         .replace(/\[\.\.\.\s*([^\]]+)\s*]/g, '*')  // Handle catch-all parameters [...param]
         .replace(/\[([^\]]+)]/g, ':$1')           // Handle regular parameters [param]
         .replace(/\/\([^)]*\)\//g, '/')          // Handle regular parameters [param]
         .replace(/\/\([^)]*\)/g, '');           // Remove parentheses and contents only if surrounded by slashes
+    
+    if(transformedPath === "") {
+        transformedPath = "/" + transformedPath;
+    }
+    
+    return transformedPath;
 }
 
 function parseDynamicRoute(name: string): { paramName?: string; routeName: string } {


### PR DESCRIPTION
- [x] Fix index routes nested in excluded folders.
- [x] Deprecate `generateRouteConfig()` in favor of `nextRoutes()`.
- [x] Add test for index routes in nested folders against "real route config".