### PR TITLE
add support for dynamic routes when using app router style

### DIFF
--- a/src/next-routes.test.ts
+++ b/src/next-routes.test.ts
@@ -367,6 +367,8 @@ describe('approuter route generation tests', () => {
             './app/folder/test/(excluded)/route.ts': 'export const helper = () => {}',
             './app/folder/test/_discarded/route.ts': 'export const helper = () => {}',
             './app/folder/test/_discarded/page.tsx': 'export const helper = () => {}',
+            './app/[...all]/route.tsx': 'console.log("Hello")',
+            './app/nested/[...all]/route.tsx': 'console.log("Hello")',
         })
     })
 
@@ -376,6 +378,8 @@ describe('approuter route generation tests', () => {
             {file: 'page.tsx', children: undefined, path: '/'},
             {file: 'folder/page.tsx', children: undefined, path: '/folder'},
             {file: 'folder/test/(excluded)/route.ts', children: undefined, path: '/folder/test'},
+            {file: '[...all]/route.tsx', children: undefined, path: "/*"},
+            {file: 'nested/[...all]/route.tsx', children: undefined, path: "/nested/*"}
         ]
 
         assert.sameDeepMembers(contents, expected, 'same members')

--- a/src/next-routes.ts
+++ b/src/next-routes.ts
@@ -104,7 +104,7 @@ export function nextRoutes(options: Options = defaultOptions): RouteConfigEntry[
      */
     function scanDir(dirPath: string) {
         return {
-            folderName: parse(dirPath).name,
+            folderName: parse(dirPath).base,
             files: readdirSync(dirPath).sort((a, b) => {
                 const {ext: aExt, name: aName} = parse(a);
                 return ((routeFileNames.includes(aName) && extensions.includes(aExt)) ? -1 : 1)
@@ -132,12 +132,12 @@ export function nextRoutes(options: Options = defaultOptions): RouteConfigEntry[
 
             const fullPath = join(dir, item);
             const stats = statSync(fullPath);
-            const {name, ext} = parse(item);
+            const {name, ext, base} = parse(item);
             const relativePath = join(baseFolder, relative(pagesDir, fullPath));
 
             if (stats.isDirectory()) {
                 // Handle nested directories
-                const nestedRoutes = scanDirectory(fullPath, `${parentPath}/${name}`);
+                const nestedRoutes = scanDirectory(fullPath, `${parentPath}/${base}`);
                 (layoutFile ? currentLevelRoutes : routes).push(...nestedRoutes);
             } else if (extensions.includes(ext)) {
                 // Early return if strict file names are enabled and the current item is not in the list.


### PR DESCRIPTION
When using the default app router options, you cannot define a catch-all route.
This is because the original logic uses `node:fs.parse` to obtain the directory's 'file'name.

As a result, if the route is something like `app/[...all]/route.ts`, the catch-all segment `[...all]` is incorrectly split into a filename `[..` and an extension `.all]`.

This PR fixes the bug by extracting the basename of the directory instead of using the parsed filename.
Also added test confirm that catch-all segment become `*`.